### PR TITLE
Fix silly typo that causes compilation error

### DIFF
--- a/src/Orchard.Web/Modules/Orchard.CRM.Core/Services/ActivityStreamService.cs
+++ b/src/Orchard.Web/Modules/Orchard.CRM.Core/Services/ActivityStreamService.cs
@@ -8,7 +8,7 @@ namespace Orchard.CRM.Core.Services
     using Orchard.CRM.Core.Models;
     using Orchard.CRM.Core.Providers.Filters;
     using Orchard.Data;
-    using Orchard.Localization;f
+    using Orchard.Localization;
     using Orchard.Users.Models;
     using System;
     using System.Collections;


### PR DESCRIPTION
Ideally some automatic build process should catch bugs like this.

Bug introduced in [7f5103c26bd3bb388c57d8e9f12098c3d66279bb](https://github.com/siyamandayubi/Orchardcollaboration/commit/7f5103c26bd3bb388c57d8e9f12098c3d66279bb)